### PR TITLE
Fix for HawkRequest package

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -150,7 +150,7 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 HAWK_CREDENTIALS = {
-    "frontend": {
+    env("HAWK_ID"): {
         "id": env("HAWK_ID"),
         "key": env("HAWK_KEY"),
         "algorithm": "sha256"


### PR DESCRIPTION
HawkRequest package doesn't allow name and id to be different in credentials. Fixed it by using the same env var.