### PR TITLE
HawkRest has a fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,8 @@ flake8-string-format==0.2.3
 gunicorn==19.8.1
 # hawkrest==1.0.0
 # HawkRest has a fix for newer Django versions middleware, which isn't yet released.
-git+https://github.com/kumar303/hawkrest.git@dce22be5a0ebbbf61e4496f38fc13478220a66b9#egg=hawkrestidna==2.6
+git+https://github.com/kumar303/hawkrest.git@dce22be5a0ebbbf61e4496f38fc13478220a66b9#egg=hawkrest
+idna==2.6
 isort==4.3.4
 lazy-object-proxy==1.3.1
 mccabe==0.6.1


### PR DESCRIPTION
 in latest commit that hasn't been released yet. We need it for latest Django. So adding commit instead