### PR TITLE
allowing frontend to push report status summary

### DIFF
--- a/api/barriers/serializers.py
+++ b/api/barriers/serializers.py
@@ -54,7 +54,6 @@ class BarrierReportSerializer(serializers.ModelSerializer):
             "id",
             "code",
             "status",
-            "status_summary",
             "status_date",
             "progress",
             "created_by",


### PR DESCRIPTION
Allowing frontend to push status summary, when the report was already resolved.