### PR TITLE
MAR-342: Stop csv getting truncated

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: python manage.py migrate && waitress-serve --port=$PORT config.wsgi:application
+web: python manage.py migrate && gunicorn --worker-class=gevent --worker-connections=1000 --workers 9 config.wsgi:application --bind 0.0.0.0:$PORT
 celeryworker: celery worker -A config.celery -l info -Q celery

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: python manage.py migrate && gunicorn --worker-class=gevent --worker-connections=1000 --workers 9 config.wsgi:application --bind 0.0.0.0:$PORT --timeout 60 --graceful-timeout 60
+web: python manage.py migrate && gunicorn --worker-class=gevent --worker-connections=1000 --workers 9 config.wsgi:application --bind 0.0.0.0:$PORT --timeout 60
 celeryworker: celery worker -A config.celery -l info -Q celery

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: python manage.py migrate && gunicorn --worker-class=gevent --worker-connections=1000 --workers 9 config.wsgi:application --bind 0.0.0.0:$PORT
+web: python manage.py migrate && gunicorn --worker-class=gevent --worker-connections=1000 --workers 9 config.wsgi:application --bind 0.0.0.0:$PORT --timeout 60
 celeryworker: celery worker -A config.celery -l info -Q celery

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: python manage.py migrate && gunicorn --worker-class=gevent --worker-connections=1000 --workers 9 config.wsgi:application --bind 0.0.0.0:$PORT --timeout 60
+web: python manage.py migrate && gunicorn --worker-class=gevent --worker-connections=1000 --workers 9 config.wsgi:application --bind 0.0.0.0:$PORT --timeout 60 --graceful-timeout 60
 celeryworker: celery worker -A config.celery -l info -Q celery

--- a/api/barriers/csv.py
+++ b/api/barriers/csv.py
@@ -22,6 +22,7 @@ def csv_iterator(rows, field_titles):
         yield BOM_UTF8
         writer = DictWriter(
             EchoUTF8(),
+            extrasaction="ignore",
             fieldnames=field_titles.keys(),
             quoting=csv.QUOTE_MINIMAL
         )

--- a/api/barriers/serializers.py
+++ b/api/barriers/serializers.py
@@ -207,7 +207,6 @@ class BarrierCsvExportSerializer(serializers.Serializer):
 
     def get_scope(self, obj):
         """  Custom Serializer Method Field for exposing current problem scope display value """
-        print(obj.__dict__)
         problem_status_dict = dict(PROBLEM_STATUS_TYPES)
         return problem_status_dict.get(obj.problem_status, "Unknown")
 
@@ -250,15 +249,6 @@ class BarrierCsvExportSerializer(serializers.Serializer):
         if obj.is_summary_sensitive:
             return "OFFICIAL-SENSITIVE (see it on DMAS)"
         else:
-            return """
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque bibendum quam at sodales commodo. Nunc porta condimentum mauris, nec euismod est ullamcorper a. Suspendisse sit amet eros eu sapien posuere vulputate non eget mauris. Ut vitae libero nisl. Aenean lectus arcu, viverra ultricies consectetur ac, pulvinar ac urna. Etiam mollis sapien ex, eu egestas ante sollicitudin vel. Mauris ac massa sed nulla cursus faucibus. Donec elementum mi vel imperdiet hendrerit. Nulla tristique vehicula dui, vehicula volutpat neque lobortis eu. Morbi vitae libero at arcu finibus commodo sed ut velit. Donec orci augue, maximus sit amet feugiat sed, luctus at dolor. Fusce ac fringilla libero.
-
-            Cras fringilla sem felis, non porttitor nulla porttitor sit amet. Praesent vitae cursus justo, et placerat purus. Ut maximus dolor id faucibus iaculis. Etiam dictum semper consequat. Fusce laoreet scelerisque gravida. Integer lobortis placerat pretium. Integer imperdiet lorem velit, bibendum feugiat neque varius nec. Quisque tempor porta lorem. Fusce efficitur, tellus id molestie cursus, lectus diam scelerisque orci, id consectetur diam massa vel libero. Suspendisse sem leo, tempor eu eros sit amet, semper suscipit lorem. Phasellus ac augue sit amet massa pharetra sollicitudin. Maecenas a purus eu nisl hendrerit blandit. Integer ultricies diam non nibh ornare viverra. Pellentesque sapien sapien, faucibus ac egestas eu, ullamcorper quis felis. Nullam eleifend dapibus nisi, in ullamcorper dui condimentum id. Vivamus ac cursus ligula.
-
-            Quisque convallis mauris nec lorem bibendum pharetra. Phasellus convallis eleifend lacus non dapibus. Suspendisse risus augue, porttitor non imperdiet ut, dictum at justo. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Aliquam eleifend nibh vitae ante hendrerit ultricies. Donec dictum nisl lorem, eget fermentum urna tincidunt sed. Proin magna justo, maximus ac vehicula ut, faucibus sit amet diam. Sed hendrerit turpis libero, non porttitor mi luctus a. Duis ornare in mauris eu fringilla.
-
-            Maecenas ac iaculis metus. Sed pharetra, nisi ac ultricies mollis, augue lacus luctus nisi, vel gravida quam ante eget enim. Cras lobortis, urna vel luctus sodales, mi nunc molestie elit, eu feugiat mi orci porta mi. Cras cursus quam ac dui vulputate interdum. Duis vehicula aliquam massa. Cras ut volutpat mi. Quisque sed eleifend felis. In convallis libero at nisl varius placerat. Duis porta justo sodales nisi viverra placerat.
-            """
             return obj.summary or None
 
     def get_sectors(self, obj):

--- a/api/barriers/serializers.py
+++ b/api/barriers/serializers.py
@@ -18,9 +18,9 @@ from api.metadata.constants import (
 from api.metadata.serializers import BarrierTagSerializer
 from api.metadata.utils import (
     adjust_barrier_tags,
-    get_admin_areas,
-    get_countries,
-    get_sectors,
+    get_admin_area,
+    get_country,
+    get_sector,
 )
 from api.wto.models import WTOProfile
 from api.wto.serializers import WTOProfileSerializer
@@ -266,36 +266,29 @@ class BarrierCsvExportSerializer(serializers.Serializer):
             if obj.all_sectors:
                 return "All"
             else:
-                dh_sectors = cache.get_or_set("dh_sectors", get_sectors, 72000)
-                sectors = []
-                if obj.sectors:
-                    for sector in obj.sectors:
-                        sectors.extend([s["name"] for s in dh_sectors if s["id"] == str(sector)])
-                return sectors
+                return [get_sector(str(sector)).get("name") for sector in obj.sectors]
         else:
             return "N/A"
 
     def get_country(self, obj):
-        dh_countries = cache.get_or_set("dh_countries", get_countries, 72000)
-        country = [c["name"] for c in dh_countries if c["id"] == str(obj.export_country)]
-        return country
+        country = get_country(str(obj.export_country))
+        if country:
+            return country.get("name")
 
     def get_overseas_region(self, obj):
-        dh_countries = cache.get_or_set("dh_countries", get_countries, 72000)
-        country = [c for c in dh_countries if c["id"] == str(obj.export_country)]
-        if len(country) > 0:
-            overseas_region = country[0].get("overseas_region", None)
-            if overseas_region is not None:
-                return overseas_region["name"]
-        return None
+        country = get_country(str(obj.export_country))
+        if country:
+            overseas_region = country.get("overseas_region")
+            if overseas_region:
+                return overseas_region.get("name")
 
     def get_admin_areas(self, obj):
-        dh_areas = cache.get_or_set("dh_admin_areas", get_admin_areas, 72000)
-        areas = []
-        if obj.country_admin_areas:
-            for area in obj.country_admin_areas:
-                areas.extend([a["name"] for a in dh_areas if a["id"] == str(area)])
-        return areas
+        admin_area_names = []
+        for admin_area in obj.country_admin_areas or []:
+            admin_area = get_admin_area(str(admin_area))
+            if admin_area and admin_area.get("name"):
+                admin_area_names.append(admin_area.get("name"))
+        return admin_area_names
 
     def get_categories(self, obj):
         return [category.title for category in obj.categories.all()]
@@ -350,13 +343,10 @@ class BarrierCsvExportSerializer(serializers.Serializer):
 
     def get_wto_member_states(self, obj):
         if obj.wto_profile:
-            dh_countries = cache.get_or_set("dh_countries", get_countries, 7200)
-            member_states_ids = [str(id) for id in obj.wto_profile.member_states]
-            member_states_names = [
-                c["name"] for c in dh_countries
-                if c["id"] in member_states_ids
+            return [
+                get_country(str(country_id)).get("name")
+                for country_id in obj.wto_profile.member_states
             ]
-            return ", ".join(member_states_names)
 
 
 class BarrierListSerializer(serializers.ModelSerializer):

--- a/api/barriers/serializers.py
+++ b/api/barriers/serializers.py
@@ -296,7 +296,9 @@ class BarrierCsvExportSerializer(serializers.Serializer):
             return "Unknown"
 
     def get_team_count(self, obj):
-        return obj.team_count
+        if hasattr(obj, "team_count"):
+            return obj.team_count
+        return TeamMember.objects.filter(barrier=obj).count()
 
     def get_tags(self, obj):
         return [tag.title for tag in obj.tags.all()]

--- a/api/barriers/serializers.py
+++ b/api/barriers/serializers.py
@@ -306,10 +306,10 @@ class BarrierCsvExportSerializer(serializers.Serializer):
             return "Unknown"
 
     def get_team_count(self, obj):
-        return TeamMember.objects.filter(barrier=obj).count()
+        return obj.team_count
 
     def get_tags(self, obj):
-        return ", ".join(obj.tags.values_list("title", flat=True))
+        return [tag.title for tag in obj.tags.all()]
 
     def get_trade_direction(self, obj):
         if obj.trade_direction:

--- a/api/barriers/serializers.py
+++ b/api/barriers/serializers.py
@@ -250,6 +250,15 @@ class BarrierCsvExportSerializer(serializers.Serializer):
         if obj.is_summary_sensitive:
             return "OFFICIAL-SENSITIVE (see it on DMAS)"
         else:
+            return """
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque bibendum quam at sodales commodo. Nunc porta condimentum mauris, nec euismod est ullamcorper a. Suspendisse sit amet eros eu sapien posuere vulputate non eget mauris. Ut vitae libero nisl. Aenean lectus arcu, viverra ultricies consectetur ac, pulvinar ac urna. Etiam mollis sapien ex, eu egestas ante sollicitudin vel. Mauris ac massa sed nulla cursus faucibus. Donec elementum mi vel imperdiet hendrerit. Nulla tristique vehicula dui, vehicula volutpat neque lobortis eu. Morbi vitae libero at arcu finibus commodo sed ut velit. Donec orci augue, maximus sit amet feugiat sed, luctus at dolor. Fusce ac fringilla libero.
+
+            Cras fringilla sem felis, non porttitor nulla porttitor sit amet. Praesent vitae cursus justo, et placerat purus. Ut maximus dolor id faucibus iaculis. Etiam dictum semper consequat. Fusce laoreet scelerisque gravida. Integer lobortis placerat pretium. Integer imperdiet lorem velit, bibendum feugiat neque varius nec. Quisque tempor porta lorem. Fusce efficitur, tellus id molestie cursus, lectus diam scelerisque orci, id consectetur diam massa vel libero. Suspendisse sem leo, tempor eu eros sit amet, semper suscipit lorem. Phasellus ac augue sit amet massa pharetra sollicitudin. Maecenas a purus eu nisl hendrerit blandit. Integer ultricies diam non nibh ornare viverra. Pellentesque sapien sapien, faucibus ac egestas eu, ullamcorper quis felis. Nullam eleifend dapibus nisi, in ullamcorper dui condimentum id. Vivamus ac cursus ligula.
+
+            Quisque convallis mauris nec lorem bibendum pharetra. Phasellus convallis eleifend lacus non dapibus. Suspendisse risus augue, porttitor non imperdiet ut, dictum at justo. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Aliquam eleifend nibh vitae ante hendrerit ultricies. Donec dictum nisl lorem, eget fermentum urna tincidunt sed. Proin magna justo, maximus ac vehicula ut, faucibus sit amet diam. Sed hendrerit turpis libero, non porttitor mi luctus a. Duis ornare in mauris eu fringilla.
+
+            Maecenas ac iaculis metus. Sed pharetra, nisi ac ultricies mollis, augue lacus luctus nisi, vel gravida quam ante eget enim. Cras lobortis, urna vel luctus sodales, mi nunc molestie elit, eu feugiat mi orci porta mi. Cras cursus quam ac dui vulputate interdum. Duis vehicula aliquam massa. Cras ut volutpat mi. Quisque sed eleifend felis. In convallis libero at nisl varius placerat. Duis porta justo sodales nisi viverra placerat.
+            """
             return obj.summary or None
 
     def get_sectors(self, obj):

--- a/api/barriers/views.py
+++ b/api/barriers/views.py
@@ -473,8 +473,10 @@ class BarriertListExportView(generics.ListAPIView):
     """
 
     queryset = BarrierInstance.barriers.annotate(
-            team_count=Count('barrier_team')
-        ).all().select_related('assessment')
+        team_count=Count('barrier_team')
+    ).all().select_related("assessment").select_related(
+        "wto_profile"
+    ).prefetch_related("tags").prefetch_related("categories")
     serializer_class = BarrierCsvExportSerializer
     filterset_class = BarrierFilterSet
     filter_backends = (DjangoFilterBackend, OrderingFilter)

--- a/api/barriers/views.py
+++ b/api/barriers/views.py
@@ -547,7 +547,7 @@ class BarriertListExportView(generics.ListAPIView):
         queryset = self.filter_queryset(self.get_queryset())
         serializer = self.get_serializer(queryset, many=True)
         base_filename = self._get_base_filename()
-        return create_csv_response(serializer.data, self.field_titles, base_filename)
+        return create_csv_response(serializer.data * 10, self.field_titles, base_filename)
 
 
 class BarrierDetail(generics.RetrieveUpdateAPIView):

--- a/api/barriers/views.py
+++ b/api/barriers/views.py
@@ -553,7 +553,7 @@ class BarriertListExportView(generics.ListAPIView):
         queryset = self.filter_queryset(self.get_queryset())
         serializer = self.get_serializer(queryset, many=True)
         base_filename = self._get_base_filename()
-        return create_csv_response(serializer.data * 20, self.field_titles, base_filename)
+        return create_csv_response(serializer.data, self.field_titles, base_filename)
 
 
 class BarrierDetail(generics.RetrieveUpdateAPIView):

--- a/api/barriers/views.py
+++ b/api/barriers/views.py
@@ -547,7 +547,7 @@ class BarriertListExportView(generics.ListAPIView):
         queryset = self.filter_queryset(self.get_queryset())
         serializer = self.get_serializer(queryset, many=True)
         base_filename = self._get_base_filename()
-        return create_csv_response(serializer.data * 10, self.field_titles, base_filename)
+        return create_csv_response(serializer.data * 20, self.field_titles, base_filename)
 
 
 class BarrierDetail(generics.RetrieveUpdateAPIView):

--- a/api/barriers/views.py
+++ b/api/barriers/views.py
@@ -475,7 +475,11 @@ class BarriertListExportView(generics.ListAPIView):
     queryset = BarrierInstance.barriers.annotate(
         team_count=Count('barrier_team')
     ).all().select_related("assessment").select_related(
-        "wto_profile"
+        "wto_profile__committee_notified"
+    ).select_related(
+        "wto_profile__committee_raised_in"
+    ).select_related(
+        "priority"
     ).prefetch_related("tags").prefetch_related("categories")
     serializer_class = BarrierCsvExportSerializer
     filterset_class = BarrierFilterSet

--- a/api/metadata/utils.py
+++ b/api/metadata/utils.py
@@ -5,6 +5,7 @@ import requests
 from urlobject import URLObject
 
 from django.conf import settings
+from django.core.cache import cache
 
 from mohawk import Sender
 
@@ -62,13 +63,39 @@ def get_os_regions_and_countries():
     return dh_os_regions, dh_countries
 
 
+def get_country(country_id):
+    country_lookup = cache.get("dh_country_lookup")
+    if not country_lookup:
+        country_lookup = {country["id"]: country for country in get_countries()}
+        cache.set("dh_country_lookup", country_lookup, 7200)
+    return country_lookup.get(country_id)
+
+
 def get_countries():
     dh_regions, dh_countries = get_os_regions_and_countries()
     return dh_countries
 
 
+def get_admin_area(admin_area_id):
+    admin_area_lookup = cache.get("dh_admin_area_lookup")
+    if not admin_area_lookup:
+        admin_area_lookup = {
+            admin_area["id"]: admin_area for admin_area in get_admin_areas()
+        }
+        cache.set("dh_admin_area_lookup", admin_area_lookup, 7200)
+    return admin_area_lookup.get(admin_area_id)
+
+
 def get_admin_areas():
     return import_api_results("administrative-area")
+
+
+def get_sector(sector_id):
+    sector_lookup = cache.get("dh_sector_lookup")
+    if not sector_lookup:
+        sector_lookup = {sector["id"]: sector for sector in get_sectors()}
+        cache.set("dh_sector_lookup", sector_lookup, 7200)
+    return sector_lookup.get(sector_id)
 
 
 def get_sectors():

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,8 @@ django-redis==4.11.0
 django-simple-history==2.8.0
 django-staff-sso-client==1.0.0
 djangorestframework==3.10.3
-gunicorn==19.9.0
+gevent==20.4.0
+gunicorn==20.0.4
 hawkrest==1.0.1
 psycopg2-binary==2.7.5
 raven==6.9.0
@@ -21,5 +22,4 @@ redis==3.4.1
 requests-toolbelt==0.8.0
 URLObject==2.4.3
 vine==1.1.4
-waitress==1.4.3
 whitenoise==4.1.3


### PR DESCRIPTION
* Switch from waitress to gunicorn to keep in line with the frontend. This also allows us to set `timeout`.
* More efficient country, admin area and sector lookups. We no longer have to loop through every country, sector etc for each row.
* More efficient database queries using `selected_related` and `prefetch_related`
* CSV `DictWriter` class is slow - use `extrasaction` parameter to speed it up
