### PR TITLE
MAR-403: Optimise dashboard

### DIFF
--- a/api/assessment/models.py
+++ b/api/assessment/models.py
@@ -5,9 +5,10 @@ from django.db.models import Q
 
 from simple_history.models import HistoricalRecords
 
-from api.metadata.constants import ASSESMENT_IMPACT
+from api.barriers.mixins import BarrierRelatedMixin
 from api.core.models import ArchivableMixin, BaseModel
 from api.interactions.models import Document
+from api.metadata.constants import ASSESMENT_IMPACT
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
 
@@ -59,7 +60,7 @@ class AssessmentHistoricalModel(models.Model):
         abstract = True
 
 
-class Assessment(ArchivableMixin, BaseModel):
+class Assessment(ArchivableMixin, BarrierRelatedMixin, BaseModel):
     """ Assessment record for a Barrier """
 
     barrier = models.OneToOneField(

--- a/api/barriers/mixins.py
+++ b/api/barriers/mixins.py
@@ -1,0 +1,11 @@
+class BarrierRelatedMixin:
+    """
+    For use by models which are related to a barrier.
+
+    Updates the related barrier's modified_on and modified_by on save.
+    """
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        self.barrier.modified_on = self.modified_on
+        self.barrier.modified_by = self.modified_by
+        self.barrier.save()

--- a/api/barriers/models.py
+++ b/api/barriers/models.py
@@ -22,9 +22,6 @@ from api.metadata.models import BarrierPriority, BarrierTag, Category
 from api.barriers import validators
 from api.barriers.report_stages import REPORT_CONDITIONS, report_stage_status
 from api.barriers.utils import random_barrier_reference
-from api.interactions.models import Interaction
-from api.assessment.models import Assessment
-from api.collaboration.models import TeamMember
 from api.wto.models import WTOProfile
 from api.metadata.constants import BARRIER_ARCHIVED_REASON
 
@@ -293,25 +290,6 @@ class BarrierInstance(FullyArchivableMixin, BaseModel):
     @property
     def has_assessment(self):
         return hasattr(self, 'assessment')
-
-    def has_changes(self, start_date, exclude_user):
-        history_querysets = [
-            self.history.all(),
-            Interaction.history.filter(barrier_id=self.id),
-            Assessment.history.filter(barrier_id=self.id),
-            TeamMember.history.filter(barrier_id=self.id).exclude(user=exclude_user),
-        ]
-        if self.wto_profile:
-            history_querysets.append(WTOProfile.history.filter(id=self.wto_profile.id))
-
-        for history_queryset in history_querysets:
-            if (
-                history_queryset.filter(
-                    history_date__gt=start_date
-                ).exclude(history_user=exclude_user).exists()
-            ):
-                return True
-        return False
 
     def last_seen_by(self, user_id):
         try:

--- a/api/barriers/models.py
+++ b/api/barriers/models.py
@@ -22,7 +22,6 @@ from api.metadata.models import BarrierPriority, BarrierTag, Category
 from api.barriers import validators
 from api.barriers.report_stages import REPORT_CONDITIONS, report_stage_status
 from api.barriers.utils import random_barrier_reference
-from api.wto.models import WTOProfile
 from api.metadata.constants import BARRIER_ARCHIVED_REASON
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH

--- a/api/collaboration/models.py
+++ b/api/collaboration/models.py
@@ -4,6 +4,7 @@ from django.db.models import Q
 
 from simple_history.models import HistoricalRecords
 
+from api.barriers.mixins import BarrierRelatedMixin
 from api.core.models import ArchivableMixin, BaseModel
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
@@ -16,7 +17,7 @@ class TeamMemberManager(models.Manager):
         return super(TeamMemberManager, self).get_queryset().filter(Q(archived=False))
 
 
-class TeamMember(ArchivableMixin, BaseModel):
+class TeamMember(ArchivableMixin, BarrierRelatedMixin, BaseModel):
     """
     TeamMember records for each Barrier
     """

--- a/api/collaboration/views.py
+++ b/api/collaboration/views.py
@@ -68,6 +68,7 @@ class BarrierTeamMemberDetail(generics.RetrieveUpdateDestroyAPIView):
             user_id = self.request.data.get("user")
             user_profile = get_object_or_404(Profile, sso_user_id=user_id)
             instance.user = user_profile.user
+            instance.modified_by = self.request.user
             instance.save()
             serializer = BarrierTeamSerializer(instance)
             return Response(status=status.HTTP_200_OK, data=serializer.data)

--- a/api/core/models.py
+++ b/api/core/models.py
@@ -43,6 +43,11 @@ class BaseModel(models.Model):
     def _cleansed_username(self, user):
         return cleansed_username(user)
 
+    def save(self, *args, **kwargs):
+        if self._state.adding and not self.modified_by:
+            self.modified_by = self.created_by
+        super().save(*args, **kwargs)
+
 
 class ArchivableMixin(models.Model):
     """Handle model archivation."""

--- a/api/interactions/models.py
+++ b/api/interactions/models.py
@@ -6,9 +6,10 @@ from django.urls import reverse
 
 from simple_history.models import HistoricalRecords
 
-from api.metadata.constants import BARRIER_INTERACTION_TYPE
+from api.barriers.mixins import BarrierRelatedMixin
 from api.core.models import ArchivableMixin, BaseModel
 from api.documents.models import AbstractEntityDocumentModel
+from api.metadata.constants import BARRIER_INTERACTION_TYPE
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
 
@@ -82,7 +83,7 @@ class InteractionHistoricalModel(models.Model):
         abstract = True
 
 
-class Interaction(ArchivableMixin, BaseModel):
+class Interaction(ArchivableMixin, BarrierRelatedMixin, BaseModel):
     """ Interaction records for each Barrier """
 
     barrier = models.ForeignKey(

--- a/api/user/models.py
+++ b/api/user/models.py
@@ -119,18 +119,20 @@ class BaseSavedSearch(models.Model):
     @property
     def new_barrier_ids(self):
         if self._new_barrier_ids is None:
-            self._new_barrier_ids = self.barriers.filter(
-                modified_on__gt=self.last_viewed_on,
-            ).exclude(
-                pk__in=self.last_viewed_barrier_ids,
-            ).exclude(
-                modified_by=self.user,
-            ).values_list("id", flat=True)
+            self._new_barrier_ids = list(
+                self.barriers.filter(
+                    modified_on__gt=self.last_viewed_on,
+                ).exclude(
+                    pk__in=self.last_viewed_barrier_ids,
+                ).exclude(
+                    modified_by=self.user,
+                ).values_list("id", flat=True)
+            )
         return self._new_barrier_ids
 
     @property
     def new_barrier_ids_since_notified(self):
-        return self.new_barriers_since_notified.values_list("id", flat=True)
+        return [barrier.id for barrier in self.new_barriers_since_notified]
 
     @property
     def new_barriers_since_notified(self):
@@ -155,13 +157,15 @@ class BaseSavedSearch(models.Model):
     @property
     def updated_barrier_ids(self):
         if self._updated_barrier_ids is None:
-            self._updated_barrier_ids = self.barriers.filter(
-                modified_on__gt=self.last_viewed_on,
-            ).exclude(
-                pk__in=self.new_barrier_ids,
-            ).exclude(
-                modified_by=self.user,
-            ).values_list("id", flat=True)
+            self._updated_barrier_ids = list(
+                self.barriers.filter(
+                    modified_on__gt=self.last_viewed_on,
+                ).exclude(
+                    pk__in=self.new_barrier_ids,
+                ).exclude(
+                    modified_by=self.user,
+                ).values_list("id", flat=True)
+            )
         return self._updated_barrier_ids
 
     @property

--- a/api/user/models.py
+++ b/api/user/models.py
@@ -119,29 +119,29 @@ class BaseSavedSearch(models.Model):
     @property
     def new_barrier_ids(self):
         if self._new_barrier_ids is None:
-            self._new_barrier_ids = []
-            new_barriers = self.barriers.exclude(pk__in=self.last_viewed_barrier_ids)
-            for barrier in new_barriers:
-                if barrier.has_changes(
-                    start_date=self.last_viewed_on,
-                    exclude_user=self.user
-                ):
-                    self._new_barrier_ids.append(barrier.id)
-
+            self._new_barrier_ids = self.barriers.filter(
+                modified_on__gt=self.last_viewed_on,
+            ).exclude(
+                pk__in=self.last_viewed_barrier_ids,
+            ).exclude(
+                modified_by=self.user,
+            ).values_list("id", flat=True)
         return self._new_barrier_ids
+
+    @property
+    def new_barrier_ids_since_notified(self):
+        return self.new_barriers_since_notified.values_list("id", flat=True)
 
     @property
     def new_barriers_since_notified(self):
         if self._new_barriers_since_notified is None:
-            self._new_barriers_since_notified = []
-            new_barriers = self.barriers.exclude(pk__in=self.last_notified_barrier_ids)
-            for barrier in new_barriers:
-                if barrier.has_changes(
-                    start_date=self.last_notified_on,
-                    exclude_user=self.user
-                ):
-                    self._new_barriers_since_notified.append(barrier)
-
+            self._new_barriers_since_notified = self.barriers.filter(
+                modified_on__gt=self.last_notified_on,
+            ).exclude(
+                pk__in=self.last_notified_barrier_ids,
+            ).exclude(
+                modified_by=self.user,
+            )
         return self._new_barriers_since_notified
 
     @property
@@ -155,25 +155,25 @@ class BaseSavedSearch(models.Model):
     @property
     def updated_barrier_ids(self):
         if self._updated_barrier_ids is None:
-            self._updated_barrier_ids = []
-            for barrier in self.barriers:
-                if barrier.has_changes(
-                    start_date=self.last_viewed_on,
-                    exclude_user=self.user
-                ):
-                    self._updated_barrier_ids.append(barrier.id)
+            self._updated_barrier_ids = self.barriers.filter(
+                modified_on__gt=self.last_viewed_on,
+            ).exclude(
+                pk__in=self.new_barrier_ids,
+            ).exclude(
+                modified_by=self.user,
+            ).values_list("id", flat=True)
         return self._updated_barrier_ids
 
     @property
     def updated_barriers_since_notified(self):
         if self._updated_barriers_since_notified is None:
-            self._updated_barriers_since_notified = []
-            for barrier in self.barriers:
-                if barrier.has_changes(
-                    start_date=self.last_notified_on,
-                    exclude_user=self.user
-                ):
-                    self._updated_barriers_since_notified.append(barrier)
+            self._updated_barriers_since_notified = self.barriers.filter(
+                modified_on__gt=self.last_notified_on,
+            ).exclude(
+                pk__in=self.new_barrier_ids_since_notified,
+            ).exclude(
+                modified_by=self.user,
+            )
         return self._updated_barriers_since_notified
 
     @property

--- a/tests/barriers/test_history.py
+++ b/tests/barriers/test_history.py
@@ -445,12 +445,11 @@ class TestHistoryView(APITestMixin, TestCase):
         self.barrier.barrier_title = "New title"
         self.barrier.save()
 
-        with freeze_time("2020-04-02"):
-            self.barrier.archive(
-                user=self.user,
-                reason="DUPLICATE",
-                explanation="It was a duplicate"
-            )
+        self.barrier.archive(
+            user=self.user,
+            reason="DUPLICATE",
+            explanation="It was a duplicate"
+        )
 
         # Note changes
         self.note.documents.add("eda7ee4e-4786-4507-a0ed-05a10169764b")
@@ -479,9 +478,8 @@ class TestHistoryView(APITestMixin, TestCase):
 
         history = response.json()["history"]
 
-        print(history)
         assert {
-            "date": "2020-04-02T00:00:00Z",
+            "date": "2020-04-01T00:00:00Z",
             "model": "barrier",
             "field": "archived",
             "old_value": {

--- a/tests/barriers/test_history.py
+++ b/tests/barriers/test_history.py
@@ -479,6 +479,7 @@ class TestHistoryView(APITestMixin, TestCase):
 
         history = response.json()["history"]
 
+        print(history)
         assert {
             "date": "2020-04-02T00:00:00Z",
             "model": "barrier",

--- a/tests/barriers/test_modified_by.py
+++ b/tests/barriers/test_modified_by.py
@@ -89,38 +89,6 @@ class BarrierModifiedByTestCase(APITestMixin, APITestCase):
         self.barrier.refresh_from_db()
         assert self.barrier.modified_by == self.user2
 
-    def test_team_member_changes_barrier_modified_by(self):
-        assert self.barrier.modified_by != self.user1
-
-        # Create a new team member
-        create_url = reverse("list-members", kwargs={"pk": self.barrier.id})
-        response = self.api_client1.post(
-            create_url,
-            format="json",
-            data={
-                "user": {"profile": {"sso_user_id": self.user1.profile.sso_user_id}},
-                "role": "Contributor",
-            }
-        )
-        assert response.status_code == status.HTTP_201_CREATED
-        team_member_id = response.data.get("id")
-
-        self.barrier.refresh_from_db()
-        assert self.barrier.modified_by == self.user1
-
-        # Update the team member - only allowed to change the owner role
-        TeamMember.objects.filter(pk=team_member_id).update(role="Owner")
-        update_url = reverse("get-member", kwargs={"pk": team_member_id})
-        response = self.api_client2.patch(
-            update_url,
-            format="json",
-            data={"user": self.user2.profile.sso_user_id}
-        )
-        assert response.status_code == status.HTTP_200_OK
-
-        self.barrier.refresh_from_db()
-        assert self.barrier.modified_by == self.user2
-
     def test_wto_changes_barrier_modified_by(self):
         assert self.barrier.modified_by != self.user1
 

--- a/tests/barriers/test_modified_by.py
+++ b/tests/barriers/test_modified_by.py
@@ -1,0 +1,136 @@
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+
+from api.collaboration.models import TeamMember
+from api.core.test_utils import APITestMixin, create_test_user
+from tests.barriers.factories import BarrierFactory
+
+
+class BarrierModifiedByTestCase(APITestMixin, APITestCase):
+    """
+    Updating models related to a barrier should update the barrier's modified_by value
+    """
+    def setUp(self):
+        self.barrier = BarrierFactory()
+        self.user1 = create_test_user(sso_user_id=self.sso_user_data_1["user_id"])
+        self.user2 = create_test_user(sso_user_id=self.sso_user_data_2["user_id"])
+        self.api_client1 = self.create_api_client(user=self.user1)
+        self.api_client2 = self.create_api_client(user=self.user2)
+
+    def test_note_changes_barrier_modified_by(self):
+        assert self.barrier.modified_by != self.user1
+
+        # Create a note
+        create_url = reverse("list-interactions", kwargs={"pk": self.barrier.id})
+        response = self.api_client1.post(create_url, json={"text": "note"})
+        assert response.status_code == status.HTTP_201_CREATED
+        interaction_id = response.data.get("id")
+
+        self.barrier.refresh_from_db()
+        assert self.barrier.modified_by == self.user1
+
+        # Update the note
+        update_url = reverse("get-interaction", kwargs={"pk": interaction_id})
+        response = self.api_client2.patch(update_url, json={"text": "updated note"})
+        assert response.status_code == status.HTTP_200_OK
+
+        self.barrier.refresh_from_db()
+        assert self.barrier.modified_by == self.user2
+
+    def test_assessment_changes_barrier_modified_by(self):
+        assert self.barrier.modified_by != self.user1
+
+        # Create an assessment
+        url = reverse("get-assessment", kwargs={"pk": self.barrier.id})
+        response = self.api_client1.post(url, json={"impact": "HIGH"})
+        assert response.status_code == status.HTTP_201_CREATED
+        assessment_id = response.data.get("id")
+
+        self.barrier.refresh_from_db()
+        assert self.barrier.modified_by == self.user1
+
+        # Update the assessment
+        response = self.api_client2.patch(url, json={"impact": "MEDIUM"})
+        assert response.status_code == status.HTTP_200_OK
+
+        self.barrier.refresh_from_db()
+        assert self.barrier.modified_by == self.user2
+
+    def test_team_member_changes_barrier_modified_by(self):
+        assert self.barrier.modified_by != self.user1
+
+        # Create a new team member
+        create_url = reverse("list-members", kwargs={"pk": self.barrier.id})
+        response = self.api_client1.post(
+            create_url,
+            format="json",
+            data={
+                "user": {"profile": {"sso_user_id": self.user1.profile.sso_user_id}},
+                "role": "Contributor",
+            }
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        team_member_id = response.data.get("id")
+
+        self.barrier.refresh_from_db()
+        assert self.barrier.modified_by == self.user1
+
+        # Update the team member - only allowed to change the owner role
+        TeamMember.objects.filter(pk=team_member_id).update(role="Owner")
+        update_url = reverse("get-member", kwargs={"pk": team_member_id})
+        response = self.api_client2.patch(
+            update_url,
+            format="json",
+            data={"user": self.user2.profile.sso_user_id}
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        self.barrier.refresh_from_db()
+        assert self.barrier.modified_by == self.user2
+
+    def test_team_member_changes_barrier_modified_by(self):
+        assert self.barrier.modified_by != self.user1
+
+        # Create a new team member
+        create_url = reverse("list-members", kwargs={"pk": self.barrier.id})
+        response = self.api_client1.post(
+            create_url,
+            format="json",
+            data={
+                "user": {"profile": {"sso_user_id": self.user1.profile.sso_user_id}},
+                "role": "Contributor",
+            }
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        team_member_id = response.data.get("id")
+
+        self.barrier.refresh_from_db()
+        assert self.barrier.modified_by == self.user1
+
+        # Update the team member - only allowed to change the owner role
+        TeamMember.objects.filter(pk=team_member_id).update(role="Owner")
+        update_url = reverse("get-member", kwargs={"pk": team_member_id})
+        response = self.api_client2.patch(
+            update_url,
+            format="json",
+            data={"user": self.user2.profile.sso_user_id}
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        self.barrier.refresh_from_db()
+        assert self.barrier.modified_by == self.user2
+
+    def test_wto_changes_barrier_modified_by(self):
+        assert self.barrier.modified_by != self.user1
+
+        # Update WTO information
+        url = reverse("get-barrier", kwargs={"pk": self.barrier.id})
+        response = self.api_client1.patch(
+            url,
+            json={"wto_profile": {"case_number": {"ABC123"}},}
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        self.barrier.refresh_from_db()
+        assert self.barrier.modified_by == self.user1


### PR DESCRIPTION
* Ensure changes made to barrier-related models (`Assessment`, `Interaction`, `TeamMember`) update the `modified_on` and `modified_by` fields for the `Barrier`.
* To work out what is `updated` and `new` for a saved search, query the barrier `modified_on` and `modified_by` instead of querying the history of the barrier and related models.