### PR TITLE
MAR-444: Increase user results limit

### DIFF
--- a/api/collaboration/serializers.py
+++ b/api/collaboration/serializers.py
@@ -1,14 +1,14 @@
 from rest_framework import serializers
 
 from api.collaboration.models import TeamMember
-from api.user.serializers import UserSerializer
+from api.user.serializers import UserListSerializer
 
 
 class BarrierTeamSerializer(serializers.ModelSerializer):
     """ Serializer for listing Barriers team members """
 
     created_by = serializers.SerializerMethodField()
-    user = UserSerializer()
+    user = UserListSerializer()
 
     class Meta:
         model = TeamMember

--- a/api/user/views.py
+++ b/api/user/views.py
@@ -13,7 +13,8 @@ from api.user.models import get_my_barriers_saved_search, get_team_barriers_save
 from api.user.serializers import (
     GroupSerializer,
     SavedSearchSerializer,
-    UserSerializer,
+    UserDetailSerializer,
+    UserListSerializer,
     WhoAmISerializer,
 )
 
@@ -48,7 +49,7 @@ def who_am_i(request):
 
 class UserDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = UserModel.objects.all()
-    serializer_class = UserSerializer
+    serializer_class = UserDetailSerializer
 
     def get_object(self):
         sso_user_id = self.kwargs.get("sso_user_id")
@@ -94,7 +95,7 @@ class GroupDetail(generics.RetrieveAPIView):
 
 class UserList(generics.ListAPIView):
     queryset = UserModel.objects.all()
-    serializer_class = UserSerializer
+    serializer_class = UserListSerializer
     filter_backends = [OrderingFilter]
     ordering_fields = ("last_name", "first_name", "email")
     ordering = ("last_name", "first_name", "email")

--- a/api/user/views.py
+++ b/api/user/views.py
@@ -99,3 +99,7 @@ class UserList(generics.ListAPIView):
     filter_backends = [OrderingFilter]
     ordering_fields = ("last_name", "first_name", "email")
     ordering = ("last_name", "first_name", "email")
+
+    def list(self, request, *args, **kwargs):
+        self.paginator.default_limit = 5000
+        return super().list(request, *args, **kwargs)


### PR DESCRIPTION
* UserList was limited to 400 results - increase this so we can fetch all users
* Split `UserSerializer` into `UserDetailSerializer` and `UserListSerializer` so we can return less data when fetching the user list