### PR TITLE
MAR-528: Fix history empty values

### DIFF
--- a/api/history/factories/base.py
+++ b/api/history/factories/base.py
@@ -50,9 +50,6 @@ class HistoryItemFactoryBase:
         if not cls.is_valid_change(new_record, old_record):
             return
 
-        if new_record.history_type == "+":
-            old_record = new_record.__class__()
-
         changed_fields = get_changed_fields(new_record, old_record)
 
         for changed_field in changed_fields:

--- a/api/history/items/barriers.py
+++ b/api/history/items/barriers.py
@@ -120,7 +120,7 @@ class StatusHistoryItem(BaseBarrierHistoryItem):
     field = "status"
 
     def is_valid(self):
-        if self.old_record.status == 0 and self.new_record.status == 7:
+        if self.old_record and self.old_record.status == 0 and self.new_record.status == 7:
             return False
         return True
 
@@ -130,7 +130,7 @@ class StatusHistoryItem(BaseBarrierHistoryItem):
             "status_date": record.status_date,
             "status_summary": record.status_summary,
             "sub_status": record.sub_status,
-            "sub_status_other":record.sub_status_other,
+            "sub_status_other": record.sub_status_other,
         }
 
 

--- a/api/history/items/base.py
+++ b/api/history/items/base.py
@@ -32,13 +32,17 @@ class BaseHistoryItem:
             data['field_info'] = self.get_field_info()
         return data
 
+    def get_empty_value(self):
+        return self.get_value(self.new_record.__class__())
+
     def get_new_value(self):
         if self.new_record:
             return self.get_value(self.new_record)
 
     def get_old_value(self):
-        if self.old_record:
-            return self.get_value(self.old_record)
+        if self.old_record is None:
+            return self.get_empty_value()
+        return self.get_value(self.old_record)
 
     def get_value(self, record):
         return getattr(record, self.field)

--- a/api/history/items/team_members.py
+++ b/api/history/items/team_members.py
@@ -5,6 +5,9 @@ class TeamMemberHistoryItem(BaseHistoryItem):
     model = "team_member"
     field = "user"
 
+    def get_empty_value(self):
+        return None
+
     def get_value(self, record):
         if record and not record.archived:
             return {

--- a/api/history/utils.py
+++ b/api/history/utils.py
@@ -1,4 +1,6 @@
 def get_changed_fields(new_record, old_record):
+    if old_record is None:
+        old_record = new_record.__class__()
     if hasattr(new_record, "get_changed_fields"):
         return new_record.get_changed_fields(old_record)
     return new_record.diff_against(old_record).changed_fields


### PR DESCRIPTION
* Ensure history items return the correct empty values instead of always using `None`
* Fixes: https://sentry.ci.uktrade.digital/dit/market-access-pyfe/issues/28849/