### PR TITLE
MAR-592: Update region filter to return barriers with matching trading blocs

### DIFF
--- a/api/barriers/filters.py
+++ b/api/barriers/filters.py
@@ -104,6 +104,9 @@ class BarrierFilterSet(django_filters.FilterSet):
             return queryset.filter(priority__in=priorities)
 
     def clean_location_value(self, value):
+        """
+        Splits a list of locations into countries, regions and trading blocs
+        """
         location_values = []
         overseas_region_values = []
         trading_bloc_values = []

--- a/api/metadata/constants.py
+++ b/api/metadata/constants.py
@@ -174,6 +174,9 @@ TRADING_BLOCS = {
             "86756b9a-5d95-e211-a939-e4115bead28a",  # Spain
             "300be5c4-5d95-e211-a939-e4115bead28a",  # Sweden
             "80756b9a-5d95-e211-a939-e4115bead28a",  # United Kingdom
+        ],
+        "overseas_regions": [
+            "3e6809d6-89f6-4590-8458-1d0dab73ad1a",  # Europe
         ]
     },
 }

--- a/tests/barriers/test_list_barriers.py
+++ b/tests/barriers/test_list_barriers.py
@@ -383,6 +383,26 @@ class TestListBarriers(APITestMixin, APITestCase):
         barrier_ids = [b["id"] for b in response.data["results"]]
         assert {str(bhutan_barrier.id), str(spain_barrier.id)} == set(barrier_ids)
 
+    def test_list_barriers_overseas_region_trading_blocs(self):
+        germany = "83756b9a-5d95-e211-a939-e4115bead28a"
+        bahamas = "a25f66a0-5d95-e211-a939-e4115bead28a"
+        europe = "3e6809d6-89f6-4590-8458-1d0dab73ad1a"
+
+        eu_barrier = BarrierFactory(trading_bloc="TB00016")
+        germany_barrier = BarrierFactory(export_country=germany)
+        bahamas_barrier = BarrierFactory(export_country=bahamas)
+
+        assert 3 == BarrierInstance.objects.count()
+
+        url = f'{reverse("list-barriers")}?location={europe}'
+        response = self.api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+
+        assert 2 == response.data["count"]
+        barrier_ids = [b["id"] for b in response.data["results"]]
+        assert {str(eu_barrier.id), str(germany_barrier.id)} == set(barrier_ids)
+
     def test_list_barriers_text_filter_based_on_title(self):
         barrier1 = BarrierFactory(barrier_title="Wibble blockade")
         _barrier2 = BarrierFactory(barrier_title="Wobble blockade")


### PR DESCRIPTION
* If the location filter includes a region, include all barriers with a trading bloc associated to that region