### PR TITLE
bump python version to version installed in Dockerfile

### DIFF
--- a/docker/local/entrypoint.sh
+++ b/docker/local/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # Django Migrations
-python3.6 manage.py makemigrations
-python3.6 manage.py migrate
+python3.7 manage.py makemigrations
+python3.7 manage.py migrate
 
 echo -e "╔══════════════════════════════════════════════════════╗"
 echo -e "                👏  Ready to roll!  👏                 "

--- a/docker/local/entrypoint.sh
+++ b/docker/local/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # Django Migrations
-python3.7 manage.py makemigrations
-python3.7 manage.py migrate
+python manage.py makemigrations
+python manage.py migrate
 
 echo -e "╔══════════════════════════════════════════════════════╗"
 echo -e "                👏  Ready to roll!  👏                 "


### PR DESCRIPTION
When running market-access-api locally the web container failed to load as the installed python version in the container seems to be a version ahead compared to the local entrypoint.sh

I've updated the binary pointed to from specific python3.6 to generic python, which always point to the correct version