### PR TITLE
TSS-203 Fix for Barrier `modified_on` values

### DIFF
--- a/api/barriers/management/commands/ugly_hack_fixing_modified_on_field.py
+++ b/api/barriers/management/commands/ugly_hack_fixing_modified_on_field.py
@@ -1,0 +1,19 @@
+from django.core.management import BaseCommand
+from django.db.models import Max, OuterRef, Subquery
+
+from ...models import Barrier
+
+
+class Command(BaseCommand):
+    """sets the modified_on field of all barriers to the date of the last history item"""
+
+    help = "sets the modified_on field of all barriers to the date of their most recent history item"
+
+    def handle(self, *args, **options):
+        Barrier.objects.update(
+            modified_on=Subquery(
+                Barrier.objects.filter(pk=OuterRef("pk")).values_list(
+                    Max("cached_history_items__date")
+                )[:1]
+            )
+        )

--- a/api/barriers/migrations/0099_populate_commercial_value.py
+++ b/api/barriers/migrations/0099_populate_commercial_value.py
@@ -14,8 +14,9 @@ def populate_commercial_value(apps, schema_editor):
     # Reconstruct commercial value history on Barrier model
     for assessment in EconomicAssessment.objects.filter(commercial_value__isnull=False):
         barrier = assessment.barrier
-        barrier.commercial_value = assessment.commercial_value
-        barrier.save()
+        Barrier.objects.filter(pk=barrier.pk).update(
+            commercial_value=assessment.commercial_value
+        )
 
         for history_item in barrier.cached_history_items.filter(
             field="commercial_value"
@@ -55,8 +56,9 @@ def populate_commercial_value_explanation(apps, schema_editor):
         commercial_value_explanation=""
     ):
         barrier = assessment.barrier
-        barrier.commercial_value_explanation = assessment.commercial_value_explanation
-        barrier.save()
+        Barrier.objects.filter(pk=barrier.pk).update(
+            commercial_value_explanation=assessment.commercial_value_explanation
+        )
 
         for history_item in barrier.cached_history_items.filter(
             field="commercial_value_explanation"

--- a/api/barriers/migrations/0123_auto_20220401_1346.py
+++ b/api/barriers/migrations/0123_auto_20220401_1346.py
@@ -36,8 +36,7 @@ def set_current_barrier_completion_percentages(apps, schema_editor):
             total += 16
 
         # Set its completed % value
-        barrier.completion_percent = total
-        barrier.save()
+        Barrier.objects.filter(pk=barrier.pk).update(completion_percent=total)
 
 
 class Migration(migrations.Migration):

--- a/tests/barriers/test_ugly_hack_fixing_modified_on_field.py
+++ b/tests/barriers/test_ugly_hack_fixing_modified_on_field.py
@@ -1,0 +1,36 @@
+import datetime
+
+from django.core import management
+from django.test import TestCase
+
+from api.barriers.models import Barrier
+from api.core.test_utils import APITestMixin
+from api.history.factories import BarrierHistoryFactory
+
+
+class TestUglyHackFixingModifiedOnField(APITestMixin, TestCase):
+    fixtures = ["barriers", "categories", "users"]
+
+    def setUp(self):
+        super().setUp()
+        self.barrier = Barrier.objects.get(pk="c33dad08-b09c-4e19-ae1a-be47796a8882")
+        self.barrier.save()
+
+    def test_modified_on_set_to_value_of_last_history_item_date(self):
+        self.barrier.companies = ["1", "2", "3"]
+        self.barrier.save()
+        # set the modified_on date of the barrier far in the future
+        far_future_date = datetime.datetime.now(
+            tz=datetime.timezone.utc
+        ) + datetime.timedelta(days=365000)
+        Barrier.objects.filter(pk=self.barrier.pk).update(modified_on=far_future_date)
+        # the following isn't necessary, but makes it possible to inspect the new date when debugging
+        self.barrier.refresh_from_db()
+
+        items = BarrierHistoryFactory.get_history_items(barrier_id=self.barrier.pk)
+        most_recent_history_item = items[-1].data
+
+        management.call_command("ugly_hack_fixing_modified_on_field")
+        self.barrier.refresh_from_db()
+
+        assert self.barrier.modified_on == most_recent_history_item["date"]


### PR DESCRIPTION
This adds a management command to patch the `modified_on` fields of `Barrier` objects that were inadvertently modified by previous migrations. It uses a management command rather than a migration as fixes for previous migrations have been included just in case, and frankly this is a pretty loathsome hack that shouldn't be applied automatically, but run manually in the full and awful knowledge of just how dreadful it is 😉