### PR TITLE
TSS-797: Delivery Confidence Summary in history item

### DIFF
--- a/api/history/items/delivery_confidence.py
+++ b/api/history/items/delivery_confidence.py
@@ -1,6 +1,7 @@
 from .base import BaseHistoryItem
 from api.metadata.constants import PROGRESS_UPDATE_CHOICES
 
+
 class BaseProgressUpdateHistoryItem(BaseHistoryItem):
     model = "progress_update"
 

--- a/api/history/items/delivery_confidence.py
+++ b/api/history/items/delivery_confidence.py
@@ -1,5 +1,5 @@
 from .base import BaseHistoryItem
-
+from api.metadata.constants import PROGRESS_UPDATE_CHOICES
 
 class BaseProgressUpdateHistoryItem(BaseHistoryItem):
     model = "progress_update"
@@ -9,9 +9,10 @@ class DeliveryConfidenceHistoryItem(BaseProgressUpdateHistoryItem):
     field = "status"
 
     def get_value(self, record):
-        if record.archived:
-            return ""
-        return record.status or ""
+        return {
+            'status': PROGRESS_UPDATE_CHOICES._display_map.get(record.status, ''),
+            'summary': record.update or ''
+        } if not record.archived else {}
 
 
 class ProgressUpdateNoteHistoryItem(BaseProgressUpdateHistoryItem):

--- a/api/history/items/delivery_confidence.py
+++ b/api/history/items/delivery_confidence.py
@@ -1,5 +1,6 @@
-from .base import BaseHistoryItem
 from api.metadata.constants import PROGRESS_UPDATE_CHOICES
+
+from .base import BaseHistoryItem
 
 
 class BaseProgressUpdateHistoryItem(BaseHistoryItem):
@@ -10,10 +11,14 @@ class DeliveryConfidenceHistoryItem(BaseProgressUpdateHistoryItem):
     field = "status"
 
     def get_value(self, record):
-        return {
-            'status': PROGRESS_UPDATE_CHOICES._display_map.get(record.status, ''),
-            'summary': record.update or ''
-        } if not record.archived else {}
+        return (
+            {
+                "status": PROGRESS_UPDATE_CHOICES._display_map.get(record.status, ""),
+                "summary": record.update or "",
+            }
+            if not record.archived
+            else {}
+        )
 
 
 class ProgressUpdateNoteHistoryItem(BaseProgressUpdateHistoryItem):

--- a/tests/barriers/test_history.py
+++ b/tests/barriers/test_history.py
@@ -652,10 +652,10 @@ class TestProgressUpdateHistory(APITestMixin, TestCase):
         # Expect (from earliest to latest):
         # ON_TRACK set, no previous
         # ON_TRACK changes to DELAYED
-        assert items[0].data["old_value"] == ""
-        assert items[0].data["new_value"] == "ON_TRACK"
-        assert items[1].data["old_value"] == "ON_TRACK"
-        assert items[1].data["new_value"] == "DELAYED"
+        assert items[0].data["old_value"] == {'status': '', 'summary': ''}
+        assert items[0].data["new_value"] == {'status': 'On track', 'summary': 'Nothing Specific'}
+        assert items[1].data["old_value"] == {'status': 'On track', 'summary': 'Nothing Specific'}
+        assert items[1].data["new_value"] == {'status': 'Delayed', 'summary': 'Nothing Specific'}
 
     def test_history_edited_progress_updates(self):
         # Ensure history returns a "created" progress update and a subsequent edit
@@ -676,10 +676,10 @@ class TestProgressUpdateHistory(APITestMixin, TestCase):
         # Expect (from earliest to latest):
         # ON_TRACK set, no previous
         # ON_TRACK changes to DELAYED
-        assert items[0].data["old_value"] == ""
-        assert items[0].data["new_value"] == "ON_TRACK"
-        assert items[1].data["old_value"] == "ON_TRACK"
-        assert items[1].data["new_value"] == "DELAYED"
+        assert items[0].data["old_value"] == {'status': '', 'summary': ''}
+        assert items[0].data["new_value"] == {'status': 'On track', 'summary': 'Nothing Specific'}
+        assert items[1].data["old_value"] == {'status': 'On track', 'summary': 'Nothing Specific'}
+        assert items[1].data["new_value"] == {'status': 'Delayed', 'summary': 'Nothing Specific'}
 
     def test_history_non_linear_updates(self):
         # Ensure history returns a sequence of "created" progress updates, and an edit to
@@ -709,12 +709,12 @@ class TestProgressUpdateHistory(APITestMixin, TestCase):
         # ON_TRACK set, no previous
         # ON_TRACK changes to DELAYED
         # ON_TRACK changes to RISK_OF_DELAY
-        assert items[0].data["old_value"] == ""
-        assert items[0].data["new_value"] == "ON_TRACK"
-        assert items[1].data["old_value"] == "ON_TRACK"
-        assert items[1].data["new_value"] == "DELAYED"
-        assert items[2].data["old_value"] == "ON_TRACK"
-        assert items[2].data["new_value"] == "RISK_OF_DELAY"
+        assert items[0].data["old_value"] == {'status': '', 'summary': ''}
+        assert items[0].data["new_value"] == {'status': 'On track', 'summary': 'Nothing Specific'}
+        assert items[1].data["old_value"] == {'status': 'On track', 'summary': 'Nothing Specific'}
+        assert items[1].data["new_value"] == {'status': 'Delayed', 'summary': 'Nothing Specific'}
+        assert items[2].data["old_value"] == {'status': 'On track', 'summary': 'Nothing Specific'}
+        assert items[2].data["new_value"] == {'status': 'Risk of delay', 'summary': 'Nothing Specific'}
 
 
 class TestCachedHistoryItems(APITestMixin, TestCase):

--- a/tests/barriers/test_history.py
+++ b/tests/barriers/test_history.py
@@ -652,10 +652,19 @@ class TestProgressUpdateHistory(APITestMixin, TestCase):
         # Expect (from earliest to latest):
         # ON_TRACK set, no previous
         # ON_TRACK changes to DELAYED
-        assert items[0].data["old_value"] == {'status': '', 'summary': ''}
-        assert items[0].data["new_value"] == {'status': 'On track', 'summary': 'Nothing Specific'}
-        assert items[1].data["old_value"] == {'status': 'On track', 'summary': 'Nothing Specific'}
-        assert items[1].data["new_value"] == {'status': 'Delayed', 'summary': 'Nothing Specific'}
+        assert items[0].data["old_value"] == {"status": "", "summary": ""}
+        assert items[0].data["new_value"] == {
+            "status": "On track",
+            "summary": "Nothing Specific",
+        }
+        assert items[1].data["old_value"] == {
+            "status": "On track",
+            "summary": "Nothing Specific",
+        }
+        assert items[1].data["new_value"] == {
+            "status": "Delayed",
+            "summary": "Nothing Specific",
+        }
 
     def test_history_edited_progress_updates(self):
         # Ensure history returns a "created" progress update and a subsequent edit
@@ -676,10 +685,19 @@ class TestProgressUpdateHistory(APITestMixin, TestCase):
         # Expect (from earliest to latest):
         # ON_TRACK set, no previous
         # ON_TRACK changes to DELAYED
-        assert items[0].data["old_value"] == {'status': '', 'summary': ''}
-        assert items[0].data["new_value"] == {'status': 'On track', 'summary': 'Nothing Specific'}
-        assert items[1].data["old_value"] == {'status': 'On track', 'summary': 'Nothing Specific'}
-        assert items[1].data["new_value"] == {'status': 'Delayed', 'summary': 'Nothing Specific'}
+        assert items[0].data["old_value"] == {"status": "", "summary": ""}
+        assert items[0].data["new_value"] == {
+            "status": "On track",
+            "summary": "Nothing Specific",
+        }
+        assert items[1].data["old_value"] == {
+            "status": "On track",
+            "summary": "Nothing Specific",
+        }
+        assert items[1].data["new_value"] == {
+            "status": "Delayed",
+            "summary": "Nothing Specific",
+        }
 
     def test_history_non_linear_updates(self):
         # Ensure history returns a sequence of "created" progress updates, and an edit to
@@ -709,12 +727,27 @@ class TestProgressUpdateHistory(APITestMixin, TestCase):
         # ON_TRACK set, no previous
         # ON_TRACK changes to DELAYED
         # ON_TRACK changes to RISK_OF_DELAY
-        assert items[0].data["old_value"] == {'status': '', 'summary': ''}
-        assert items[0].data["new_value"] == {'status': 'On track', 'summary': 'Nothing Specific'}
-        assert items[1].data["old_value"] == {'status': 'On track', 'summary': 'Nothing Specific'}
-        assert items[1].data["new_value"] == {'status': 'Delayed', 'summary': 'Nothing Specific'}
-        assert items[2].data["old_value"] == {'status': 'On track', 'summary': 'Nothing Specific'}
-        assert items[2].data["new_value"] == {'status': 'Risk of delay', 'summary': 'Nothing Specific'}
+        assert items[0].data["old_value"] == {"status": "", "summary": ""}
+        assert items[0].data["new_value"] == {
+            "status": "On track",
+            "summary": "Nothing Specific",
+        }
+        assert items[1].data["old_value"] == {
+            "status": "On track",
+            "summary": "Nothing Specific",
+        }
+        assert items[1].data["new_value"] == {
+            "status": "Delayed",
+            "summary": "Nothing Specific",
+        }
+        assert items[2].data["old_value"] == {
+            "status": "On track",
+            "summary": "Nothing Specific",
+        }
+        assert items[2].data["new_value"] == {
+            "status": "Risk of delay",
+            "summary": "Nothing Specific",
+        }
 
 
 class TestCachedHistoryItems(APITestMixin, TestCase):


### PR DESCRIPTION
Delivery confidence history items currently only display the status change. This PR also returns the description a user put for the progress update.
