### PR TITLE
Fix - TSS-1357 - Missing Action Plan Assigned to Sentry error

### DIFF
--- a/api/history/items/action_plans.py
+++ b/api/history/items/action_plans.py
@@ -121,8 +121,8 @@ class ActionPlanTaskAssignedToHistoryItem(ActionPlanTaskHistoryItem):
             # Check that the user exists
             user = getattr(record, "assigned_to", None)
             if not user:
-                raise ObjectDoesNotExist
-        except ObjectDoesNotExist:
+                raise ValueError
+        except (ObjectDoesNotExist, ValueError):
             # default to me if user does not exist.
             backup_user = get_default_user()
             record.user = backup_user

--- a/api/history/items/action_plans.py
+++ b/api/history/items/action_plans.py
@@ -120,6 +120,8 @@ class ActionPlanTaskAssignedToHistoryItem(ActionPlanTaskHistoryItem):
         try:
             # Check that the user exists
             user = getattr(record, "assigned_to", None)
+            if not user:
+                raise ObjectDoesNotExist
         except ObjectDoesNotExist:
             # default to me if user does not exist.
             backup_user = get_default_user()

--- a/api/history/items/action_plans.py
+++ b/api/history/items/action_plans.py
@@ -119,16 +119,16 @@ class ActionPlanTaskAssignedToHistoryItem(ActionPlanTaskHistoryItem):
     def get_value(self, record):
         try:
             # Check that the user exists
-            user = getattr(record, "assigned_to", None)
-            if not user:
+            assigned_to_user = getattr(record, "assigned_to", None)
+            if not assigned_to_user:
                 raise ValueError
         except (ObjectDoesNotExist, ValueError):
             # default to me if user does not exist.
-            backup_user = get_default_user()
-            record.user = backup_user
+            assigned_to_user = get_default_user()
+            record.assigned_to = assigned_to_user
             record.save()
 
-        return self._format_user(record.assigned_to).get("name")
+        return self._format_user(assigned_to_user).get("name")
 
 
 class ActionPlanTaskStakeholdersHistoryItem(ActionPlanTaskHistoryItem):


### PR DESCRIPTION
Sometimes an ActionPlan may not have a user associated with it under assigned_to, if not, then we use the backup_user instead.

https://sentry.ci.uktrade.digital/organizations/dit/issues/103087/?environment=production&project=121&referrer=alert_email