### PR TITLE
Feature - TSS-1331 - Display related barriers similarity score

### DIFF
--- a/api/barriers/serializers/barriers.py
+++ b/api/barriers/serializers/barriers.py
@@ -144,3 +144,4 @@ class BarrierRelatedListSerializer(serializers.Serializer):
     modified_on = serializers.DateTimeField(read_only=True)
     status = StatusField(required=False)
     location = serializers.CharField(read_only=True)
+    similarity = serializers.FloatField(read_only=True)


### PR DESCRIPTION
getting rid of Barrier objects method as unnecessary, return a DataFrame not a queryset.

Similarity score now - as part of this dataframe - gets passed to the serializer for response.

Removed caching as we want to test quickly and will be fixed as part of a different ticket