### PR TITLE
hotfix: Public Barrier unpublished changes type

### DIFF
--- a/api/barriers/serializers/public_barriers.py
+++ b/api/barriers/serializers/public_barriers.py
@@ -56,7 +56,7 @@ class NestedPublicBarrierSerializer(serializers.ModelSerializer):
         )
 
     def get_unpublished_changes(self, obj):
-        return obj.unpublished_changes
+        return bool(obj.unpublished_changes)
 
     def get_changed_since_published(self, obj):
         return obj.changed_since_published


### PR DESCRIPTION
`barrier.unpublished_changes` property was initially returning a boolean, but has been changed to return a list. The public barrier serializer returns the raw value, so any process previously expecting a boolean would now receive a list instead (Dataworkspace). This change casts the list to boolean